### PR TITLE
Update Podfile to use IQKeyboardManager 6.0.0

### DIFF
--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'IQKeyboardManager', '~> 5.0.0'
+pod 'IQKeyboardManager', '~> 6.0.0'


### PR DESCRIPTION
Can we update to use IQKeyboardManager v6? v5 doesn't work well on the latest iOS. I tested with v6 and seems to work fine.